### PR TITLE
Add AGENTS instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Instructions for Repository Contributors
+
+- To launch the simulator, run `python3 main.py` from the repository root.
+- After making any code changes, check for syntax errors by running:
+  ```bash
+  python3 -m py_compile **/*.py
+  ```


### PR DESCRIPTION
## Summary
- create instructions for repository contributors
- ignore local Python bytecode

## Testing
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python3 -m py_compile **/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68401babf608832597f73745d465947e