### PR TITLE
Fix duplicate braking message

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,7 +107,6 @@ try:
         # Navigation
         state_str = "forward"
         if obstacle_sparse:
-            print("🛑 Braking")
             state_str = navigator.brake()
         else:
             state_str = navigator.blind_forward()


### PR DESCRIPTION
## Summary
- remove extra `print` before navigator brake call

## Testing
- `python3 -m py_compile **/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68401df3fccc8325af4dca1c39a59fe0