### PR TITLE
Allow custom path for Blocks executable

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -42,7 +42,7 @@ ReactiveOpticalFlow/
 
 ## Running the Simulation
 
-1. Launch the AirSim environment or let `main.py` start the Blocks executable configured inside the script.
+1. Launch the AirSim environment or let `main.py` start the Blocks executable. Set the `BLOCKS_EXE_PATH` environment variable to the location of your `Blocks.exe` file if it differs from the default.
 2. Run the program:
 
    ```bash

--- a/main.py
+++ b/main.py
@@ -20,7 +20,12 @@ param_refs = {
 start_gui(param_refs)
 
 # === Launch Unreal Engine simulation ===
-ue4_exe = r"C:\Users\newso\Documents\AirSimExperiments\BlocksBuild\WindowsNoEditor\Blocks\Binaries\Win64\Blocks.exe"
+# Path to the Blocks executable. This can be overridden by setting the
+# BLOCKS_EXE_PATH environment variable.
+ue4_exe = os.environ.get(
+    "BLOCKS_EXE_PATH",
+    r"C:\Users\newso\Documents\AirSimExperiments\BlocksBuild\WindowsNoEditor\Blocks\Binaries\Win64\Blocks.exe",
+)
 try:
     sim_process = subprocess.Popen([ue4_exe, "-windowed", "-ResX=1280", "-ResY=720"])
     print("Launching Unreal Engine simulation...")


### PR DESCRIPTION
## Summary
- add option to load Blocks path from `BLOCKS_EXE_PATH` environment variable
- document the new environment variable in the README

## Testing
- `python3 -m py_compile **/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68401df2f50c8325916934f6760d0541