### PR TITLE
Add optical flow vector visualization

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,6 +10,7 @@ This project implements a real-time **sparse** optical flow-based navigation sys
 * 📁 Structured modular code with reusable components
 * ▶️ Automatically launches the Unreal Engine Blocks environment
 * 🖥️ Optional debug window showing tracked features when `DEBUG_DISPLAY=1`
+* 🎞️ Output video overlays flow vectors for each tracked feature
 
 ## Project Structure
 

--- a/main.py
+++ b/main.py
@@ -93,6 +93,8 @@ try:
         img = cv2.resize(img, (640, 480))
         gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
         vis_img = img.copy()
+        good_old = np.empty((0, 2), dtype=np.float32)
+        good_new = np.empty((0, 2), dtype=np.float32)
 
         # Sparse flow detection
         obstacle_sparse = False
@@ -105,7 +107,7 @@ try:
                 print(f"🔍 Initialized {features_detected} features")
             print("🔧 First grayscale frame set")
         else:
-            obstacle_sparse, prev_pts = track_and_detect_obstacle(
+            obstacle_sparse, prev_pts, good_old, good_new = track_and_detect_obstacle(
                 prev_gray_sparse,
                 gray,
                 prev_pts,
@@ -165,6 +167,13 @@ try:
         cv2.putText(vis_img, f"State: {state_str}", (10, 85), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255,255,255), 2)
         cv2.putText(vis_img, f"Sim Time: {time_now-start_time:.2f}s", (10, 115), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255,255,255), 2)
         cv2.putText(vis_img, f"Features: {features_detected}", (10, 145), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255,255,255), 2)
+
+        # Draw flow vectors
+        for pt_old, pt_new in zip(good_old, good_new):
+            x1, y1 = pt_old.ravel()
+            x2, y2 = pt_new.ravel()
+            cv2.arrowedLine(vis_img, (int(x1), int(y1)), (int(x2), int(y2)), (0, 255, 0), 1, tipLength=0.3)
+            cv2.circle(vis_img, (int(x2), int(y2)), 2, (0, 255, 0), -1)
 
         if DEBUG_DISPLAY and prev_pts is not None:
             for p in prev_pts:

--- a/sparse_optical_flow_utils.py
+++ b/sparse_optical_flow_utils.py
@@ -26,6 +26,8 @@ def track_and_detect_obstacle(prev_gray, curr_gray, prev_pts, roi,
     Performs Lucas-Kanade tracking and returns:
     - obstacle_detected (bool)
     - new_points for continued tracking
+    - good_old: valid points from the previous frame
+    - good_new: corresponding new positions of valid points
     """
     prev_gray = apply_clahe(prev_gray)
     curr_gray = apply_clahe(curr_gray)
@@ -37,7 +39,8 @@ def track_and_detect_obstacle(prev_gray, curr_gray, prev_pts, roi,
     good_new = new_pts[status == 1]
 
     if len(good_new) < 2:
-        return False, new_pts  # Not enough points to analyze
+        # Not enough points to analyze
+        return False, new_pts, np.array([]), np.array([])
 
     # Filter points whose new position falls inside the ROI
     roi_mask = (
@@ -51,7 +54,8 @@ def track_and_detect_obstacle(prev_gray, curr_gray, prev_pts, roi,
     roi_new = good_new[roi_mask]
 
     if len(roi_new) < 2:
-        return False, new_pts
+        # Not enough points inside ROI for obstacle detection
+        return False, new_pts, good_old, good_new
 
     # Compute displacement magnitudes of ROI features
     disp = roi_new - roi_old
@@ -66,6 +70,6 @@ def track_and_detect_obstacle(prev_gray, curr_gray, prev_pts, roi,
     threshold = displacement_threshold * (1 + drone_speed)
 
     if avg_mag > threshold:
-        return True, new_pts
+        return True, new_pts, good_old, good_new
 
-    return False, new_pts
+    return False, new_pts, good_old, good_new


### PR DESCRIPTION
## Summary
- extend `track_and_detect_obstacle` to also return valid point pairs
- render arrows for each sparse flow vector in `main.py`
- document flow vector overlay in README

## Testing
- `python3 -m py_compile **/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68402401d3488325a1619f6793013239