### PR TITLE
Add corridor awareness and dodging

### DIFF
--- a/main.py
+++ b/main.py
@@ -157,13 +157,22 @@ try:
         if frame_count < GRACE_FRAMES:
             obstacle_sparse = False
 
+        threshold = 2.5 * max(speed, 0.2)
+        corridor = (
+            smooth_C <= threshold
+            and smooth_L > threshold
+            and smooth_R > threshold
+        )
+        if corridor:
+            obstacle_sparse = False
+
         # Navigation
         state_str = "forward"
         if obstacle_sparse:
             safe_counter = 0
-            state_str = navigator.brake()
+            state_str = navigator.dodge(smooth_L, smooth_C, smooth_R)
         else:
-            if navigator.braked:
+            if navigator.braked or navigator.dodging:
                 safe_counter += 1
                 print(f"[DEBUG] clear frames: {safe_counter}/{SAFE_FRAMES}")
 
@@ -171,7 +180,10 @@ try:
                     state_str = navigator.resume_forward()
                     safe_counter = 0
                 else:
-                    state_str = navigator.brake()
+                    if navigator.braked:
+                        state_str = navigator.brake()
+                    else:
+                        state_str = "dodge"
             else:
                 state_str = navigator.blind_forward()
 

--- a/sparse_optical_flow_utils.py
+++ b/sparse_optical_flow_utils.py
@@ -91,7 +91,11 @@ def track_and_detect_obstacle(prev_gray, curr_gray, prev_pts, roi,
 
     print(f"[DEBUG] ROI avg flow: {avg_mag:.2f}, Threshold: {threshold:.2f}, Speed: {drone_speed:.2f}")
 
-    if avg_mag > threshold:
-        return True, new_pts, good_old, good_new, partition_avgs
+    obstacle_detected = False
+    if partitions >= 3:
+        center_flow = partition_avgs[partitions // 2]
+        obstacle_detected = center_flow > threshold
+    else:
+        obstacle_detected = avg_mag > threshold
 
-    return False, new_pts, good_old, good_new, partition_avgs
+    return obstacle_detected, new_pts, good_old, good_new, partition_avgs


### PR DESCRIPTION
## Summary
- detect forward obstacles using centre partition flow
- skip braking when only side partitions report high flow (corridor)
- dodge left or right when an obstacle is ahead

## Testing
- `python3 -m py_compile **/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684033f2319883258d7600fac80eb6a9