### PR TITLE
Fix false obstacle triggers and improve debug output

### DIFF
--- a/main.py
+++ b/main.py
@@ -146,6 +146,10 @@ try:
         if part_flows:
             flow_history.update(*part_flows)
         smooth_L, smooth_C, smooth_R = flow_history.average()
+        print(
+            f"[DEBUG] smoothed flows L/C/R: {smooth_L:.2f}, "
+            f"{smooth_C:.2f}, {smooth_R:.2f}"
+        )
 
         if no_feature_frames >= NO_FEATURE_LIMIT:
             print("❌ No features for several frames — resetting tracker")
@@ -157,13 +161,23 @@ try:
         if frame_count < GRACE_FRAMES:
             obstacle_sparse = False
 
+        threshold = 2.5 * max(speed, 0.2)
+        obstacle_sparse = smooth_C > threshold
+        corridor = (
+            smooth_C <= threshold
+            and smooth_L > threshold
+            and smooth_R > threshold
+        )
+        if corridor:
+            obstacle_sparse = False
+
         # Navigation
         state_str = "forward"
         if obstacle_sparse:
             safe_counter = 0
-            state_str = navigator.brake()
+            state_str = navigator.dodge(smooth_L, smooth_C, smooth_R)
         else:
-            if navigator.braked:
+            if navigator.braked or navigator.dodging:
                 safe_counter += 1
                 print(f"[DEBUG] clear frames: {safe_counter}/{SAFE_FRAMES}")
 
@@ -171,7 +185,10 @@ try:
                     state_str = navigator.resume_forward()
                     safe_counter = 0
                 else:
-                    state_str = navigator.brake()
+                    if navigator.braked:
+                        state_str = navigator.brake()
+                    else:
+                        state_str = "dodge"
             else:
                 state_str = navigator.blind_forward()
 

--- a/sparse_optical_flow_utils.py
+++ b/sparse_optical_flow_utils.py
@@ -89,9 +89,19 @@ def track_and_detect_obstacle(prev_gray, curr_gray, prev_pts, roi,
     effective_speed = max(drone_speed, 0.2)
     threshold = displacement_threshold * effective_speed
 
-    print(f"[DEBUG] ROI avg flow: {avg_mag:.2f}, Threshold: {threshold:.2f}, Speed: {drone_speed:.2f}")
+    print(
+        f"[DEBUG] ROI avg flow: {avg_mag:.2f}, "
+        f"Threshold: {threshold:.2f}, Speed: {drone_speed:.2f}"
+    )
+    if partitions >= 3:
+        flows_str = ", ".join(f"{p:.2f}" for p in partition_avgs)
+        print(f"[DEBUG] Partition flows L/C/R: {flows_str}")
 
-    if avg_mag > threshold:
-        return True, new_pts, good_old, good_new, partition_avgs
+    obstacle_detected = False
+    if partitions >= 3:
+        center_flow = partition_avgs[partitions // 2]
+        obstacle_detected = center_flow > threshold
+    else:
+        obstacle_detected = avg_mag > threshold
 
-    return False, new_pts, good_old, good_new, partition_avgs
+    return obstacle_detected, new_pts, good_old, good_new, partition_avgs


### PR DESCRIPTION
## Summary
- print per-partition flow values in `track_and_detect_obstacle`
- log smoothed flow values in `main` and use them for obstacle checks

## Testing
- `python3 -m py_compile **/*.py`
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684033f2319883258d7600fac80eb6a9